### PR TITLE
当页码是二位数或三位数时，显示不居中问题

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,7 +252,8 @@ table,table tbody tr th {
 }
 
 .pagination>li>a {
-	color: #333
+	color: #333;
+	padding: 6px 0px
 }
 
 .next,.pagination .next,.prev {


### PR DESCRIPTION
当页码出现二位数或三位数时，由于左padding，数字没有局中，如下：

![11](http://www.zhuyuntao.cn/wp-content/uploads/2019/05/2019-05-09_141545.jpg)