### PR TITLE
add contents picture

### DIFF
--- a/inc/options-framework/js/options-custom.js
+++ b/inc/options-framework/js/options-custom.js
@@ -92,10 +92,12 @@ jQuery(document).ready(function ($) {
 
   jQuery("#g_thumbnail").click(function () {
     jQuery("#section-g_postthumbnail").fadeToggle(400);
+    jQuery("#section-essay_feature_img_usable").fadeToggle(400);
   });
 
   if (jQuery("#g_thumbnail:checked").val() !== undefined) {
     jQuery("#section-g_postthumbnail").show();
+    jQuery("#section-essay_feature_img_usable").show();
   }
 
   jQuery("#top_select").change(function () {

--- a/inc/theme-article.php
+++ b/inc/theme-article.php
@@ -126,7 +126,13 @@ function post_thumbnail()
         if (!empty($img_val)) {
             echo '<img src="' . $img_val . '" />';
         } else {
-            if (!kratos_option('g_postthumbnail')) {
+            $category=get_the_category($post->ID);
+            $catid=$category[0]->term_id;
+            if(kratos_option('essay_feature_img_'.$catid) 
+            && kratos_option('essay_feature_img_usable',true))
+            {
+                $img = kratos_option('essay_feature_img_'.$catid);
+            }elseif(!kratos_option('g_postthumbnail')) {
                 $img = ASSET_PATH . '/assets/img/default.jpg';
             } else {
                 $img = kratos_option('g_postthumbnail', ASSET_PATH . '/assets/img/default.jpg');

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -361,6 +361,15 @@ function kratos_options()
     );
 
     $options[] = array(
+        'name' => __('开启目录默认特色图片', 'kratos'),
+        'desc' => __('为每一个目录设置一个默认的特色图片', 'kratos'),
+        'std' => '1',
+        'class' => 'hidden',
+        'id' => 'essay_feature_img_usable',
+        'type' => 'checkbox',
+    );
+
+    $options[] = array(
         'name' => __('默认特色图', 'kratos'),
         'desc' => __('当文章中没有图片并且没有设置特色图时在首页显示', 'kratos'),
         'id' => 'g_postthumbnail',
@@ -368,7 +377,25 @@ function kratos_options()
         'std' => ASSET_PATH . '/assets/img/default.jpg',
         'type' => 'upload',
     );
-
+        #在这里获取所有分类的名称和id 然后加入到设置中
+    if(kratos_option('essay_feature_img_usable',true)){
+        $args=array(
+            'orderby' => 'name',
+            'order' => 'ASC',
+            #设置获取没有文章的空类
+            'hide_empty' => false
+            );
+        $categories=get_categories($args);
+        foreach($categories as $category) {
+            $options[] = array(
+                'name' => __( $category->name.'分类默认特色图片', 'kratos'),
+                'desc' => __('没有设置默认图片时，按照文章分类默认给出', 'kratos'),
+                'id' => ('essay_feature_img_'.$category->term_id),
+                'std' => ASSET_PATH . '/assets/img/default.jpg',
+                'type' => 'upload',
+            );
+            }
+        }
     $options[] = array(
         'name' => __('无内容图片', 'kratos'),
         'desc' => __('当搜索不到文章或文章分类中没有文章时显示', 'kratos'),


### PR DESCRIPTION
增加分类默认的特色图片，在文章没有内容没有任何图片且没有为文章设置特色图图片时，会使用对应目录所设置的默认特色图图片。
使用方法：在主题设置中的首页配置中，勾选开启目录默认特色图片，然后保存一下配置，就能在首页配置中看到每个目录的默认特色图片设置选项，然后根据选项设置即可。