### PR TITLE
improve responsiveness of article pagination buttons

### DIFF
--- a/assets/css/kratos.css
+++ b/assets/css/kratos.css
@@ -501,6 +501,14 @@ button:focus {
 4. 分页按钮
 --------------------------------------------------------------*/
 
+.k-main .board .paginations > * {
+    display: inline-block;
+}
+
+.k-main .board .paginations .kicon {
+    line-height: 25px;
+}
+
 .k-main .board .paginations {
   margin: 23px auto;
   width: 100%;

--- a/assets/css/kratos.css
+++ b/assets/css/kratos.css
@@ -517,13 +517,14 @@ button:focus {
 }
 
 .k-main .board .paginations a {
+  margin-top: 5px;
   padding: 5px 12px;
   background: #fff;
   color: #444;
 }
 
 .k-main .board .paginations .current {
-  padding: 8px 12px;
+  padding: 5px 12px;
   background: #00a2ff;
   color: #fff;
   font-weight: 400;

--- a/assets/css/kratos.css
+++ b/assets/css/kratos.css
@@ -517,7 +517,7 @@ button:focus {
 }
 
 .k-main .board .paginations a {
-  padding: 8px 12px;
+  padding: 5px 12px;
   background: #fff;
   color: #444;
 }
@@ -530,7 +530,7 @@ button:focus {
 }
 
 .k-main .board .paginations .dots {
-  padding: 8px 12px;
+  padding: 5px 12px;
   background: #fff;
   color: #444;
 }


### PR DESCRIPTION
by introducing:
* fix wrapped articles pagination button in next line is overlapping first line when viewport width is too small
* reduce other article pagination buttons height to emphasize current page

Previous:
![](https://user-images.githubusercontent.com/13030387/118413526-60e5ea80-b6d2-11eb-91ee-014836e8e89f.png)
After:
![](https://user-images.githubusercontent.com/13030387/118413528-62171780-b6d2-11eb-8d63-eb31faf25a70.png)
