### PR TITLE
add esc_attr() to prevent XSS & show comment username in latest_comments widget

### DIFF
--- a/inc/theme-setting.php
+++ b/inc/theme-setting.php
@@ -49,7 +49,7 @@ function keywords()
     } else {
         $keywords = single_tag_title('', false);
     }
-    return trim(strip_tags($keywords));
+    return trim(esc_attr(strip_tags($keywords)));
 }
 
 // Description 配置
@@ -77,7 +77,7 @@ function description()
             $description = kratos_option('seo_description');
         }
     }
-    return trim(strip_tags($description));
+    return trim(esc_attr(strip_tags($description)));
 }
 
 // robots.txt 配置

--- a/inc/theme-widgets.php
+++ b/inc/theme-widgets.php
@@ -54,7 +54,7 @@ function most_comm_posts($days = 30, $nums = 6)
             $commentcount = $topten->comment_count;
             if ($commentcount >= 0) {
                 $output .= '<a class="bookmark-item" title="' . $title . '" href="' . get_permalink($postid) . '" rel="bookmark"><i class="kicon i-book"></i>';
-                $output .= strip_tags($title);
+                $output .= esc_attr(strip_tags($title));
                 $output .= '</a>';
             }
         }
@@ -112,7 +112,7 @@ function latest_comments($list_number=5, $cut_length=50)
     global $wpdb,$output;
     $comments = $wpdb->get_results("SELECT DISTINCT ID, post_title, post_password, comment_ID, comment_post_ID, comment_author, comment_date_gmt, comment_approved, comment_type, comment_author_url, comment_author_email, comment_content AS com_excerpt FROM $wpdb->comments LEFT OUTER JOIN $wpdb->posts ON ($wpdb->comments.comment_post_ID = $wpdb->posts.ID) WHERE comment_approved = '1' AND (comment_type = '' OR comment_type = 'comment') AND user_id != '1' AND post_password = '' ORDER BY comment_date_gmt DESC LIMIT $list_number");
     foreach ($comments as $comment) {
-        $output .= ' <a href="'.get_the_permalink($comment->comment_post_ID) .'#commentform"> <div class="meta clearfix"> <div class="avatar float-left">'.get_avatar( $comment, 60 ).'</div> <div class="profile d-block"> <span class="date"> '.__( '发布于 ' , 'kratos').timeago($comment->comment_date_gmt).'</span> <span class="message d-block">'.convert_smilies(string_cut(strip_tags($comment->com_excerpt), $cut_length)).'</span> </div> </div> </a>';
+        $output .= ' <a href="'.get_the_permalink($comment->comment_post_ID) .'#commentform"> <div class="meta clearfix"> <div class="avatar float-left">'.get_avatar( $comment, 60 ).'</div> <div class="profile d-block"> <span class="date"> '.__( '发布于 ' , 'kratos').timeago($comment->comment_date_gmt).'</span> <span class="message d-block">'.convert_smilies(esc_attr(string_cut(strip_tags($comment->com_excerpt), $cut_length))).'</span> </div> </div> </a>';
     }
     return $output;
 }
@@ -397,7 +397,7 @@ class widget_posts extends WP_Widget
         <div class="tab-content" id="nav-tabContent">
             <div class="tab-pane fade <?php echo $active = ($order == 'new') ? 'show active' : null; ?>" id="nav-new" role="tabpanel" aria-labelledby="nav-new-tab">
             <?php $myposts = get_posts('numberposts=' . $number . ' & offset=0');foreach ($myposts as $post): ?>
-                <a class="bookmark-item" title="<?php echo $post->post_title; ?>" href="<?php echo get_permalink($post->ID); ?>" rel="bookmark"><i class="kicon i-book"></i><?php echo strip_tags($post->post_title) ?></a>
+                <a class="bookmark-item" rel="bookmark" title="<?php echo esc_attr(strip_tags($post->post_title)); ?>" href="<?php echo get_permalink($post->ID); ?>"><i class="kicon i-book"></i><?php echo esc_attr(strip_tags($post->post_title)); ?></a>
             <?php endforeach;?>
             </div>
             <div class="tab-pane fade <?php echo $active = ($order == 'hot') ? 'show active' : null; ?>" id="nav-hot" role="tabpanel" aria-labelledby="nav-hot-tab">
@@ -405,7 +405,7 @@ class widget_posts extends WP_Widget
             </div>
             <div class="tab-pane fade <?php echo $active = ($order == 'random') ? 'show active' : null; ?>" id="nav-random" role="tabpanel" aria-labelledby="nav-random-tab">
             <?php $myposts = get_posts('numberposts=' . $number . ' & offset=0 & orderby=rand');foreach ($myposts as $post): ?>
-                <a class="bookmark-item" title="<?php echo $post->post_title; ?>" href="<?php echo get_permalink($post->ID); ?>" rel="bookmark"><i class="kicon i-book"></i><?php echo strip_tags($post->post_title) ?></a>
+                <a class="bookmark-item" rel="bookmark" title="<?php echo esc_attr(strip_tags($post->post_title)); ?>" href="<?php echo get_permalink($post->ID); ?>"><i class="kicon i-book"></i><?php echo esc_attr(strip_tags($post->post_title)); ?></a>
             <?php endforeach;?>
             </div>
         </div>

--- a/inc/theme-widgets.php
+++ b/inc/theme-widgets.php
@@ -109,10 +109,10 @@ function string_cut($string, $sublen, $start = 0, $code = 'UTF-8') {
 
 function latest_comments($list_number=5, $cut_length=50)
 {
-    global $wpdb,$output;
-    $comments = $wpdb->get_results("SELECT DISTINCT ID, post_title, post_password, comment_ID, comment_post_ID, comment_author, comment_date_gmt, comment_approved, comment_type, comment_author_url, comment_author_email, comment_content AS com_excerpt FROM $wpdb->comments LEFT OUTER JOIN $wpdb->posts ON ($wpdb->comments.comment_post_ID = $wpdb->posts.ID) WHERE comment_approved = '1' AND (comment_type = '' OR comment_type = 'comment') AND user_id != '1' AND post_password = '' ORDER BY comment_date_gmt DESC LIMIT $list_number");
+    global $wpdb, $output;
+    $comments = $wpdb->get_results("SELECT comment_ID, comment_post_ID, comment_author, comment_date_gmt, comment_content FROM {$wpdb->comments} LEFT OUTER JOIN {$wpdb->posts} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID WHERE comment_approved = '1' AND (comment_type = '' OR comment_type = 'comment') AND user_id != '1' AND post_password = '' ORDER BY comment_date_gmt DESC LIMIT {$list_number}");
     foreach ($comments as $comment) {
-        $output .= ' <a href="'.get_the_permalink($comment->comment_post_ID) .'#commentform"> <div class="meta clearfix"> <div class="avatar float-left">'.get_avatar( $comment, 60 ).'</div> <div class="profile d-block"> <span class="date"> '.__( '发布于 ' , 'kratos').timeago($comment->comment_date_gmt).'</span> <span class="message d-block">'.convert_smilies(esc_attr(string_cut(strip_tags($comment->com_excerpt), $cut_length))).'</span> </div> </div> </a>';
+        $output .= '<a href="' . get_the_permalink($comment->comment_post_ID) . '#commentform"> <div class="meta clearfix"> <div class="avatar float-left">' . get_avatar($comment, 60) . '</div> <div class="profile d-block"> <span class="date">' . esc_attr($comment->comment_author) . ' ' . __('发布于 ', 'kratos') . timeago($comment->comment_date_gmt) . '</span> <span class="message d-block">' . convert_smilies(esc_attr(string_cut(strip_tags($comment->comment_content), $cut_length))) . '</span> </div> </div> </a>';
     }
     return $output;
 }

--- a/inc/theme-widgets.php
+++ b/inc/theme-widgets.php
@@ -50,11 +50,11 @@ function most_comm_posts($days = 30, $nums = 6)
     if (!empty($result)) {
         foreach ($result as $topten) {
             $postid = $topten->ID;
-            $title = $topten->post_title;
+            $title = esc_attr(strip_tags($topten->post_title));
             $commentcount = $topten->comment_count;
             if ($commentcount >= 0) {
                 $output .= '<a class="bookmark-item" title="' . $title . '" href="' . get_permalink($postid) . '" rel="bookmark"><i class="kicon i-book"></i>';
-                $output .= esc_attr(strip_tags($title));
+                $output .= $title;
                 $output .= '</a>';
             }
         }


### PR DESCRIPTION
* add esc_attr() on strip_tags() to prevent XSS @ inc/theme-widgets.php
* show comment username in latest_comments widget
and removed unused comment metadata since get_avatar only needs comment_ID, see source of get_avatar(): https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/pluggable.php#L2691 and get_comment(): https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/comment.php#L203
and now will show multiple comments within same post due to removal of `DISTINCT ID`