### PR TITLE
文章页的最近评论小工具中评论发布时间的相对时间永远是刚刚

### DIFF
--- a/inc/theme-widgets.php
+++ b/inc/theme-widgets.php
@@ -144,14 +144,14 @@ function string_cut($string, $sublen, $start = 0, $code = 'UTF-8')
 function latest_comments($list_number = 5, $cut_length = 50)
 {
     global $wpdb, $output;
-    $comments = $wpdb->get_results($wpdb->prepare("SELECT comment_ID, comment_post_ID, comment_author, comment_author_email, comment_date, comment_content FROM {$wpdb->comments} LEFT OUTER JOIN {$wpdb->posts} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID WHERE comment_approved = '1' AND (comment_type = '' OR comment_type = 'comment') AND user_id != '1' AND post_password = '' ORDER BY comment_date_gmt DESC LIMIT %d", $list_number));
+    $comments = $wpdb->get_results($wpdb->prepare("SELECT comment_ID, comment_post_ID, comment_author, comment_author_email, comment_date_gmt, comment_content FROM {$wpdb->comments} LEFT OUTER JOIN {$wpdb->posts} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID WHERE comment_approved = '1' AND (comment_type = '' OR comment_type = 'comment') AND post_password = '' ORDER BY comment_date_gmt DESC LIMIT %d", $list_number));
     foreach ($comments as $comment) {
         $nickname = esc_attr($comment->comment_author) ?: __('匿名', 'kratos');
         $output .= '<a href="' . get_the_permalink($comment->comment_post_ID) . '#commentform">
             <div class="meta clearfix">
                 <div class="avatar float-left">' . get_avatar($comment, 60) . '</div>
                 <div class="profile d-block">
-                    <span class="date">' . $nickname . ' ' . __('发布于 ', 'kratos') . timeago($comment->comment_date) . '（' . wp_date(__('m月d日', 'kratos'), strtotime($comment->comment_date)) . '）</span>
+                    <span class="date">' . $nickname . ' ' . __('发布于 ', 'kratos') . timeago($comment->comment_date_gmt) . '（' . wp_date(__('m月d日', 'kratos'), strtotime($comment->comment_date_gmt)) . '）</span>
                     <span class="message d-block">' . convert_smilies(esc_attr(string_cut(strip_tags($comment->comment_content), $cut_length))) . '</span>
                 </div>
             </div>


### PR DESCRIPTION
在https://github.com/seatonjiang/kratos/blob/3704666d5ea672e63049b3275880b099c55e3257/inc/theme-widgets.php#L101 添加以下log会发现不同页面有着不同的php默认时区设置，原因未知
![image](https://user-images.githubusercontent.com/13030387/172580486-3409c7b6-aeed-4e68-a870-d1ef53ef58b6.png)

首页：
![image](https://user-images.githubusercontent.com/13030387/172580513-bcdba29c-5380-482d-86d2-5f3289c01d8c.png)

文章页：
![image](https://user-images.githubusercontent.com/13030387/172580702-3477e8f3-c489-4630-95c3-f2e64e2511b7.png)

由于默认时区不同所以给此`strtotime()`传入非utc时区的字符串形式日期时间（形如2022-06-08 17:00:00的mysql datetime格式）会导致`$dtime`变量值为负数从而对所有评论的发布时间求相对时间结果都为`刚刚`
https://github.com/seatonjiang/kratos/blob/3704666d5ea672e63049b3275880b099c55e3257/inc/theme-widgets.php#L103

另外删除了sql中`AND (wp_posts表.)user_id != '1'`where条件，uid 1一般都是站长用户