### PR TITLE
fix still trying to init `window.lightGallery()` even after disabled `g_lightgallery` in theme settings

### DIFF
--- a/assets/js/kratos.js
+++ b/assets/js/kratos.js
@@ -149,7 +149,7 @@
     }
 
     var lightGalleryConfig = function () {
-        if(kratos.lightgallery){
+        if (kratos.lightgallery === '1' && window.lightGallery !== undefined) {
             lightGallery(document.getElementById('lightgallery'), {
                 selector: 'a[href$=".jpg"], a[href$=".jpeg"], a[href$=".png"], a[href$=".gif"], a[href$=".bmp"], a[href$=".webp"]'
             })

--- a/inc/theme-core.php
+++ b/inc/theme-core.php
@@ -42,6 +42,7 @@ function theme_autoload()
         wp_enqueue_style('kicon', ASSET_PATH . '/assets/css/iconfont.min.css', array(), THEME_VERSION);
         wp_enqueue_style('layer', ASSET_PATH . '/assets/css/layer.min.css', array(), '3.1.1');
         if (kratos_option('g_lightgallery', true)) {
+            wp_enqueue_script('lightgallery', ASSET_PATH . '/assets/js/lightgallery.min.js', array(), '1.4.0', true);
             wp_enqueue_style('lightgallery', ASSET_PATH . '/assets/css/lightgallery.min.css', array(), '1.4.0');
         }
         if (kratos_option('g_animate', false)) {
@@ -98,7 +99,6 @@ function theme_autoload()
         wp_enqueue_script('bootstrap-bundle', ASSET_PATH . '/assets/js/bootstrap.bundle.min.js', array(), '4.5.0', true);
         wp_enqueue_script('layer', ASSET_PATH . '/assets/js/layer.min.js', array(), '3.1.1', true);
         wp_enqueue_script('dplayer', ASSET_PATH . '/assets/js/DPlayer.min.js', array(), THEME_VERSION, true);
-        wp_enqueue_script('lightgallery', ASSET_PATH . '/assets/js/lightgallery.min.js', array(), '1.4.0', true);
         wp_enqueue_script('kratos', ASSET_PATH . '/assets/js/kratos.js', array(), THEME_VERSION, true);
 
         $data = array(


### PR DESCRIPTION
https://github.com/seatonjiang/kratos/issues/507#issuecomment-1355153374
> @jalena @g93920079 新增了一个灯箱的控制开关，后期考虑更换一个效果更好的，更新新版本即可。
> 
> <img alt="image" width="435" src="https://user-images.githubusercontent.com/57834639/204134657-cb99fab8-ba81-4cf6-b19c-a9c0aa893598.png">

![image](https://user-images.githubusercontent.com/13030387/216948776-68a84a73-0270-457c-9392-d98293971dfa.png)

https://github.com/seatonjiang/kratos/blob/8e158679fd887e8ca967c79dd6eefada7f0ddf53/inc/theme-options.php#L685
